### PR TITLE
feat: adding unimplemented Stop() method

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -193,3 +193,4 @@ func (p *Provisioner) resolvePath(path string) (string, error) {
 
 	return "", fmt.Errorf("Path not valid: [%s]", relativePath)
 }
+

--- a/resource_provisioner.go
+++ b/resource_provisioner.go
@@ -18,6 +18,18 @@ type ResourceProvisioner struct {
 	extraVars map[string]string // extra variables that can be passed to the provisioner
 }
 
+
+func (r *ResourceProvisioner) Stop() error {
+	provisioner, err := r.decodeConfig(c)
+	if err != nil {
+		o.Output("error decoding provisioner")
+		return err
+	}
+
+	// implement stop
+}
+
+
 func (r *ResourceProvisioner) Apply(
 	o terraform.UIOutput,
 	s *terraform.InstanceState,


### PR DESCRIPTION
Added stub Stop() method to ResourceProvisioner.

This lets the plugin compile against version 0.9.3 of Terraform without errors.